### PR TITLE
Add activity dropdown and move sheet URL to secrets (v3.2.0)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,8 @@ jobs:
         run: |
           echo "const APP_CONFIG = {"                                    > config.js
           echo "    scriptWriteUrl: '${{ secrets.SCRIPT_WRITE_URL }}'," >> config.js
-          echo "    scriptReadUrl:  '${{ secrets.SCRIPT_READ_URL }}'"   >> config.js
+          echo "    scriptReadUrl:  '${{ secrets.SCRIPT_READ_URL }}',"  >> config.js
+          echo "    sheetUrl:       '${{ secrets.SHEET_URL }}'"         >> config.js
           echo "};"                                                      >> config.js
 
       - name: Deploy to gh-pages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,137 @@
+# CLAUDE.md — 家用記帳 專案交接文件
+
+## 專案概覽
+
+家用記帳 PWA，使用者為 Jerry_Hu 與 Alice_Lin 兩人家庭。
+前端純 Vanilla JS，後端為 Google Apps Script + Google Sheets，透過 GitHub Actions 部署。
+
+- **目前版本**：v3.2.0
+- **Sheets URL**：存於 `config.js`（gitignored），不在原始碼中
+
+---
+
+## 技術架構
+
+| 層級 | 技術 |
+|------|------|
+| 前端 | Vanilla JS + 自製 CSS（無框架） |
+| 後端 | Google Apps Script（GAS） |
+| 資料庫 | Google Sheets |
+| 部署 | GitHub Actions（main 分支推送自動部署至 gh-pages） |
+| 快取 | localStorage（Store / Detail 自動完成，最多各 50 筆） |
+
+### 敏感設定（gitignored）
+
+`config.js` 包含以下三個欄位，部署時由 GitHub Actions Secrets 自動產生：
+
+| 欄位 | Secret 名稱 | 說明 |
+|------|------------|------|
+| `scriptWriteUrl` | `SCRIPT_WRITE_URL` | GAS 寫入端點 |
+| `scriptReadUrl` | `SCRIPT_READ_URL` | GAS 讀取端點 |
+| `sheetUrl` | `SHEET_URL` | Google Sheets 完整 URL |
+
+---
+
+## Google Sheets 結構
+
+### `config` 分頁（原 `annualBudget`，v3.2.0 重新命名）
+
+| 欄 | 列 | 內容 |
+|----|----|------|
+| A–C | 1 | 標題列（項目 / 預算 / 比例） |
+| A–B | 2–11 | 10 個支出大類預算 |
+| A–C | 13 | Total 合計 |
+| E | 1 | 活動清單標題 |
+| E | 2–51 | 活動名稱（最多 50 筆） |
+
+支出大類順序（對應 `topclass[2]` index，必須與年度 sheet 一致）：
+
+```
+index 0: 飲食   1: 衣裝   2: 居住   3: 交通   4: 教育
+index 5: 娛樂   6: 健康   7: 社交   8: 育兒   9: 其他
+```
+
+### 年度 sheet（如 `2026`）
+
+Row 11–20，Col B–C：各支出大類年度已使用金額。
+
+```
+Row 11: 飲食    Row 12: 衣裝    Row 13: 居住    Row 14: 交通
+Row 15: 教育    Row 16: 娛樂    Row 17: 健康    Row 18: 社交
+Row 19: 育兒    Row 20: 其他
+```
+
+> ⚠️ v3.1.1 新增「育兒」（index 8），年度 sheet 需在 row 19 插入育兒統計列，否則已使用金額會錯位。
+
+---
+
+## script.js 關鍵 fetch 參數
+
+```js
+// 預算（config 分頁，跳過標題列）
+const budgets      = { sheetUrl: APP_CONFIG.sheetUrl, sheetTag: 'config',                    row: 2,  col: 1, endRow: 11, endCol: 2 };
+// 年度已使用金額（當年度 sheet）
+const nowusing     = { sheetUrl: APP_CONFIG.sheetUrl, sheetTag: new Date().getFullYear(),     row: 11, col: 2, endRow: 20, endCol: 3 };
+// 活動清單（config 分頁 E 欄）
+const activityParams = { sheetUrl: APP_CONFIG.sheetUrl, sheetTag: 'config',                  row: 2,  col: 5, endRow: 51, endCol: 5 };
+```
+
+> ⚠️ 三個 fetch 物件都必須帶 `sheetUrl`（`APP_CONFIG.sheetUrl`）。
+> 若缺少，GAS `openByUrl(undefined)` 拋例外 → CORS 錯誤（HTTP 200 無 CORS header）。
+
+---
+
+## GAS 函式說明
+
+### `doGet(e)`（scriptReadUrl）
+
+讀取任意 sheet 指定範圍，回傳逗號分隔字串。
+
+**已套用修正**（`row > lastRow` 邊界處理）：
+```js
+if (row > lastRow || col > lastCol) {
+    return ContentService.createTextOutput('');
+}
+rowRange = Math.min(rowRange, lastRow - row + 1);
+colRange = Math.min(colRange, lastCol - col + 1);
+```
+
+### `doPost(e)`（scriptWriteUrl）
+
+寫入記帳資料至 `active` sheet（依 header 欄位對應）。
+前端使用 `no-cors` 模式送出，無法讀取回應為正常行為。
+
+---
+
+## 表單欄位對應（HTML → Sheets）
+
+| HTML name | Sheets 欄位 | 說明 |
+|-----------|------------|------|
+| Month | Month | 自動從 Date 計算（hidden） |
+| Date | Date | 日期 |
+| Balance | Balance | 收入 / 支出 |
+| Topclass | Topclass | 大類 |
+| Subclass | Subclass | 小類 |
+| Price | Price | 金額 |
+| Store | Store | 店家 |
+| Detail | Detail | 項目 |
+| Recommendation | Recommendation | 推薦星評 |
+| Remark | Remark | **活動名稱**（config E 欄下拉） |
+| Name | Name | 使用者（Jerry_Hu / Alice_Lin） |
+
+---
+
+## 活動清單管理
+
+- 維護於 `config` 分頁 E 欄（E1 標題，E2 起為活動名稱）
+- 新增：E 欄末列新增一列；停用：刪除或清空該列
+- 上限 50 筆（E2:E51）；需要更多請調高 `activityParams.endRow`
+- 編輯 Sheets 後，兩位使用者重新整理 App 即同步
+
+---
+
+## 待辦事項（詳見 TODO.md）
+
+1. **B2 活動管理**：App 內直接新增活動（需修改 GAS `doPost` 加入 `action=addActivity` 分支）
+2. **後台數據儀表板**：網頁版年度統計 + 活動彙整，新增 `dashboard.html`，密碼存於 `config.js`
+3. **Sheets 重整**：複製新試算表取得全新 URL → 更新 GAS 與 GitHub Secrets → 清除 git history 舊 URL

--- a/README.md
+++ b/README.md
@@ -1,15 +1,63 @@
-# 家用記帳
+# Home Sweet Home — Household Bookkeeping
 
-A lightweight household bookkeeping PWA that submits entries to Google Sheets via Google Apps Script.
+A lightweight household bookkeeping PWA for two users. Entries are submitted to Google Sheets via Google Apps Script, with no server required.
+
+## Features
+
+- Income / expense entry with category hierarchy (大類 / 小類)
+- Real-time budget remaining display per expense category
+- Activity tagging — link entries to a trip or event for cross-category aggregation
+- Store / item autocomplete via localStorage
+- Star rating for restaurants and stores
+- Two-user support (Jerry_Hu / Alice_Lin)
+- Offline-capable PWA (manifest, iOS meta tags, SVG icon)
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Frontend | Vanilla JS + custom CSS (no frameworks) |
+| Backend | Google Apps Script (GAS) |
+| Database | Google Sheets |
+| Deployment | GitHub Actions → GitHub Pages |
+| Cache | localStorage (autocomplete, max 50 entries each) |
+
+---
 
 ## Setup
 
-1. Copy `config.example.js` to `config.js` and fill in your GAS endpoints.
-2. Set `SCRIPT_WRITE_URL` and `SCRIPT_READ_URL` as GitHub Actions secrets for CI deployment.
+1. Copy `config.example.js` to `config.js` and fill in your URLs:
+   - `scriptWriteUrl` — GAS write endpoint
+   - `scriptReadUrl` — GAS read endpoint
+   - `sheetUrl` — Google Sheets URL
+
+2. Add the following as GitHub Actions secrets for CI deployment:
+   - `SCRIPT_WRITE_URL`
+   - `SCRIPT_READ_URL`
+   - `SHEET_URL`
+
+---
+
+## Activity List Management
+
+The activity list is maintained in the Google Sheets **`config` tab, column E** (E1 = header, E2 onwards = activity names).
+
+- **Add an activity**: insert a new row below the last entry in column E
+- **Remove an activity**: delete or clear that row
+- Changes sync to both users on next app refresh
+- Maximum 50 entries (E2:E51); increase `activityParams.endRow` in [script.js](script.js) if more are needed
 
 ---
 
 ## Release History
+
+- May 02, 2026  **v3.2.0**
+    - Feature: Remark field replaced with activity dropdown, populated from Google Sheets `config` tab column E
+    - Feature: `config` sheet replaces `annualBudget`, consolidating budget and activity list management
+    - Security: Google Sheets URL moved out of source code into `config.js` (gitignored) and `SHEET_URL` Actions secret
+    - Fix: Budget data now reads from row 2 (skipping header row), resolving NaN display
+    - Fix: GAS `doGet` boundary check for `row > lastRow` to prevent CORS exception
+    - Fix: PWA meta tag updated from `apple-mobile-web-app-capable` to `mobile-web-app-capable`
 
 - May 02, 2026  **v3.1.1**
     - Category overhaul: added 育兒 top-level category with 10 subcategories
@@ -17,24 +65,23 @@ A lightweight household bookkeeping PWA that submits entries to Google Sheets vi
     - Removed jQuery and Bootstrap dependencies (replaced with native fetch and custom CSS)
     - CI/CD: GitHub Actions deployment with secret-based config.js generation
     - Security: rotated GAS endpoints; config.js excluded from git history
-    - UX: star rating first option now shows ""-""
+    - UX: star rating first option now shows "-"
     - UX: topclass/subclass dropdowns hidden until relevant balance is selected
-    - UX: required indicator added to 店家/項目 field
+    - UX: required indicator added to store/item field
     - Fix: iOS date input appearance
     - Refactored all inline scripts to `script.js`
-    - Security: GAS endpoints moved to gitignored `config.js`; `config.example.js` added
-    - Error handling: `alert()` replaced with in-page alerts; `no-cors` mode to fix CORS false-failure; submit button disabled during request
+    - Error handling: `alert()` replaced with in-page alerts; `no-cors` mode to fix CORS false-failure
     - UX: keep category selection after send; auto-focus price field for consecutive entry
     - UX: budget loading indicator and error state
-    - UX: Store/Detail autocomplete via `localStorage`; clear history link
+    - UX: store/detail autocomplete via localStorage; clear history link
     - UI: card layout, Noto Sans TC, field labels, radio pill selectors
     - Mobile: price field `inputmode="decimal"`
-    - PWA: `manifest.json`, SVG app icon, iOS meta tags, favicon
+    - PWA: `manifest.json`, SVG icon, iOS meta tags, favicon
     - Fix: date timezone bug (local date instead of UTC)
-    - Fix: Reset restores today's date; balance-list and month field reset correctly
+    - Fix: Reset restores today's date and resets all fields correctly
     - Cleanup: removed DataTables, duplicate Bootstrap import, `projects/` folder
-    
-- Jan 19, 2025 **v2.3.0**
+
+- Jan 19, 2025  **v2.3.0**
     - Items added
 
 - Mar 15, 2023  **v2.2.5**
@@ -86,4 +133,8 @@ A lightweight household bookkeeping PWA that submits entries to Google Sheets vi
 
 ## TODO
 
-- Activity tag feature: tag entries with a trip or event name to aggregate cross-category spending (see [TODO.md](TODO.md))
+- **B2**: Add activities directly from the app (currently requires editing Google Sheets)
+- **Analytics dashboard**: Password-protected web dashboard for yearly statistics and activity summaries
+- **Sheets migration**: Copy spreadsheet to get a new URL, update GAS and GitHub Secrets, clean git history
+
+See [TODO.md](TODO.md) for details.

--- a/TODO.md
+++ b/TODO.md
@@ -1,17 +1,46 @@
 # TODO
 
-## 活動標籤 / 跨類別彙整花費
+## B2：App 內新增活動
+
+目前新增活動需直接編輯 Google Sheets `config` 分頁 E 欄。
+若要在 App 內直接新增：
+
+- GAS `doPost` 加入 `action=addActivity` 分支，寫入 config E 欄下一個空列
+- App 活動下拉旁加「＋」按鈕，輸入後 POST 至 `scriptWriteUrl`
+- 前端樂觀更新（`no-cors` 無法讀取回應，直接加入本地清單）
+
+詳細實作方式可參考對話記錄。
+
+---
+
+## 後台數據儀表板（網頁版）
 
 **背景**
-單筆記帳目前只能屬於一個大類（如飲食、交通），
-無法跨類別彙整「同一趟旅遊／同一次活動」的所有花費。
+目前各年度統計資料存於 Google Sheets，需直接開啟試算表才能檢視。
+希望未來能在記帳網頁上進入有密碼保護的後台，直接查看統計數據。
 
 **需求**
-- 記帳時可選擇關聯到某個「活動」（如：2025 日本旅遊、婚禮）
-- 後台可依活動標籤列出該活動的所有明細與總額
-- 活動清單需可自行新增、命名
+- 輸入密碼後進入後台（密碼存於 `config.js`，gitignore 保護）
+- 顯示各年度花費統計（月份 / 類別分析）
+- 顯示各活動花費明細與總額彙整
+- 資料來源透過現有 `scriptReadUrl` 從 Google Sheets 讀取
 
 **影響範圍**
-- 前端：新增活動選擇欄位（可為選填下拉或文字輸入）
-- 後端 Google Apps Script：寫入時帶入活動欄位
-- Google Sheets：新增活動欄位；建立活動彙整工作表或 filter view
+- 前端：新增 `dashboard.html` 或單頁切換模式
+- Google Sheets：確認各年度統計分頁格式，供 `scriptReadUrl` 讀取
+- 認證：前端密碼驗證（`config.js` 存放）
+
+---
+
+## Sheets 重整與安全性
+
+**背景**
+舊版原始碼中有 Google Sheets URL 硬編碼（已於 v3.2.0 移除）。
+目前已將 Sheets 共用設定改為「限制存取」作為緊急處置。
+
+**後續處理**
+1. 複製現有試算表 → 取得全新 URL（舊 URL 永久失效）
+2. 在新試算表重新部署 GAS 腳本
+3. 更新 GitHub Secrets：`SHEET_URL`、`SCRIPT_WRITE_URL`、`SCRIPT_READ_URL`
+4. 確認新 Sheets 結構與現有程式碼一致（尤其年度 sheet row 11–20 順序）
+5. 選擇性清除 git history 中的舊 URL（`git filter-repo`）

--- a/config.example.js
+++ b/config.example.js
@@ -1,6 +1,7 @@
-// Copy this file to config.js and fill in your Google Apps Script URLs.
+// Copy this file to config.js and fill in your URLs.
 // config.js is gitignored — never commit the real URLs.
 const APP_CONFIG = {
     scriptWriteUrl: 'YOUR_WRITE_SCRIPT_URL_HERE',
-    scriptReadUrl:  'YOUR_READ_SCRIPT_URL_HERE'
+    scriptReadUrl:  'YOUR_READ_SCRIPT_URL_HERE',
+    sheetUrl:       'YOUR_GOOGLE_SHEET_URL_HERE'
 };

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
     <link rel="manifest" href="manifest.json">
     <meta name="theme-color" content="#4a7c4e">
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="記帳">
     <link rel="apple-touch-icon" href="icons/icon.svg">
@@ -28,11 +28,10 @@
             <div class="form-card__header">
                 <div class="form-card__title">
                     家用記帳
-                    <span class="form-card__version">v3.1.1</span>
+                    <span class="form-card__version">v3.2.0</span>
                 </div>
                 <div class="form-card__meta">
-                    <a href="https://docs.google.com/spreadsheets/d/1ZNPbB2IAaM23TGnwfXr4bTbijXXBPwMMNTZa_O5ERhE/edit?usp=sharing"
-                        target="_blank">試算表</a>
+                    <a href="#" id="sheet-link" target="_blank">試算表</a>
                     <span>STLin &copy; <span id="year"></span></span>
                 </div>
             </div>
@@ -76,8 +75,10 @@
                     </div>
 
                     <div class="field-group">
-                        <label class="field-label">備註</label>
-                        <input name="Remark" type="text" placeholder="Remark (i.e. name of activity)">
+                        <label class="field-label">活動</label>
+                        <select name="Remark" id="remark-list">
+                            <option value="">載入中...</option>
+                        </select>
                     </div>
 
                     <div class="field-group">

--- a/script.js
+++ b/script.js
@@ -30,6 +30,7 @@ const stars = ['-', '☆☆☆☆☆', '★☆☆☆☆', '★★☆☆☆', '�
 var arrBudget = [];
 var arrUsed = [];
 var budgetReady = false;
+var arrActivities = [];
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 function buildOptions(arr) {
@@ -153,6 +154,7 @@ function OnReset() {
 
 // ── Initialization (script has defer, so DOM is ready here) ───────────────────
 document.getElementById('year').textContent = new Date().getFullYear();
+document.getElementById('sheet-link').href  = APP_CONFIG.sheetUrl;
 document.getElementById('fdate').value = todayString();
 changeDate();
 
@@ -200,20 +202,31 @@ form.addEventListener('submit', e => {
 
 // Fetch budget data from Google Sheets
 const budgets = {
-    sheetUrl: 'https://docs.google.com/spreadsheets/d/1ZNPbB2IAaM23TGnwfXr4bTbijXXBPwMMNTZa_O5ERhE/edit?pli=1#gid=1968068763',
-    sheetTag: 'annualBudget',
-    row: 1, col: 1, endRow: 10, endCol: 2
+    sheetUrl: APP_CONFIG.sheetUrl,
+    sheetTag: 'config',
+    row: 2, col: 1, endRow: 11, endCol: 2
 };
 const nowusing = {
-    sheetUrl: 'https://docs.google.com/spreadsheets/d/1ZNPbB2IAaM23TGnwfXr4bTbijXXBPwMMNTZa_O5ERhE/edit?pli=1#gid=1968068763',
+    sheetUrl: APP_CONFIG.sheetUrl,
     sheetTag: new Date().getFullYear(),
     row: 11, col: 2, endRow: 20, endCol: 3
+};
+const activityParams = {
+    sheetUrl: APP_CONFIG.sheetUrl,
+    sheetTag: 'config',
+    row: 2, col: 5, endRow: 51, endCol: 5
 };
 
 function fetchSheet(params) {
     const url = new URL(scriptReadUrl);
     Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
     return fetch(url).then(r => r.text());
+}
+
+function populateActivities() {
+    var el = document.getElementById('remark-list');
+    el.innerHTML = '<option value="">-</option>' +
+        arrActivities.map(a => '<option value="' + a + '">' + a + '</option>').join('');
 }
 
 (async () => {
@@ -234,4 +247,14 @@ function fetchSheet(params) {
         el.style.color = 'gray';
         el.innerHTML = '預算資料載入失敗';
     }
+})();
+
+(async () => {
+    try {
+        const d = await fetchSheet(activityParams);
+        arrActivities = d.split(',').map(s => s.trim()).filter(s => s.length > 0);
+    } catch {
+        arrActivities = [];
+    }
+    populateActivities();
 })();


### PR DESCRIPTION
- Remark field replaced with activity <select> populated from Google Sheets config tab column E via scriptReadUrl
- Google Sheets URL moved from source code to config.js (gitignored) and SHEET_URL GitHub Actions secret
- Fix: budget fetch now starts at row 2 (skipping header), resolving NaN display
- Fix: GAS doGet boundary check for row > lastRow to prevent CORS exception
- Fix: PWA meta tag updated to mobile-web-app-capable
- Docs: README rewritten in English with full feature/setup documentation
- Docs: CLAUDE.md added for AI context handoff
- Docs: TODO.md updated with B2, dashboard, and Sheets migration items