### PR TITLE
[Fix]: Move sheet URL to secrets and update CI actions (v3.2.1)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,18 +11,22 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
       - name: Generate config.js from secrets
+        env:
+          SCRIPT_WRITE_URL: ${{ secrets.SCRIPT_WRITE_URL }}
+          SCRIPT_READ_URL: ${{ secrets.SCRIPT_READ_URL }}
+          SHEET_URL: ${{ secrets.SHEET_URL }}
         run: |
-          echo "const APP_CONFIG = {"                                    > config.js
-          echo "    scriptWriteUrl: '${{ secrets.SCRIPT_WRITE_URL }}'," >> config.js
-          echo "    scriptReadUrl:  '${{ secrets.SCRIPT_READ_URL }}',"  >> config.js
-          echo "    sheetUrl:       '${{ secrets.SHEET_URL }}'"         >> config.js
-          echo "};"                                                      >> config.js
+          printf "const APP_CONFIG = {\n"                          > config.js
+          printf "    scriptWriteUrl: '%s',\n" "$SCRIPT_WRITE_URL" >> config.js
+          printf "    scriptReadUrl:  '%s',\n" "$SCRIPT_READ_URL"  >> config.js
+          printf "    sheetUrl:       '%s'\n"  "$SHEET_URL"        >> config.js
+          printf "};\n"                                            >> config.js
 
       - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 家用記帳 PWA，使用者為 Jerry_Hu 與 Alice_Lin 兩人家庭。
 前端純 Vanilla JS，後端為 Google Apps Script + Google Sheets，透過 GitHub Actions 部署。
 
-- **目前版本**：v3.2.0
+- **目前版本**：v3.2.1
 - **Sheets URL**：存於 `config.js`（gitignored），不在原始碼中
 
 ---

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ The activity list is maintained in the Google Sheets **`config` tab, column E** 
 
 ## Release History
 
+- May 03, 2026  **v3.2.1**
+    - Security: Google Sheets URL moved to `config.js` (gitignored) and `SHEET_URL` Actions secret
+    - CI: deploy.yml uses `printf` + env vars to safely handle URLs containing special characters
+    - CI: updated `actions/checkout` to v4.2.2 and `peaceiris/actions-gh-pages` to v4 (Node.js 24 support, required from June 2, 2026)
+
 - May 02, 2026  **v3.2.0**
     - Feature: Remark field replaced with activity dropdown, populated from Google Sheets `config` tab column E
     - Feature: `config` sheet replaces `annualBudget`, consolidating budget and activity list management

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
             <div class="form-card__header">
                 <div class="form-card__title">
                     家用記帳
-                    <span class="form-card__version">v3.2.0</span>
+                    <span class="form-card__version">v3.2.1</span>
                 </div>
                 <div class="form-card__meta">
                     <a href="#" id="sheet-link" target="_blank">試算表</a>


### PR DESCRIPTION
- Google Sheets URL moved from source code to config.js (gitignored) and new SHEET_URL GitHub Actions secret
- deploy.yml switched from echo to printf + env vars to safely handle URLs containing special characters (e.g. #)
- Updated actions/checkout to v4.2.2 and peaceiris/actions-gh-pages to v4 for Node.js 24 compatibility (required from June 2, 2026)