### PR TITLE
Add tag management and remove parenting category (v3.3.0)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4.2.2
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 家用記帳 PWA，使用者為 Jerry_Hu 與 Alice_Lin 兩人家庭。
 前端純 Vanilla JS，後端為 Google Apps Script + Google Sheets，透過 GitHub Actions 部署。
 
-- **目前版本**：v3.2.1
+- **目前版本**：v3.3.0
 - **Sheets URL**：存於 `config.js`（gitignored），不在原始碼中
 
 ---
@@ -39,29 +39,29 @@
 | 欄 | 列 | 內容 |
 |----|----|------|
 | A–C | 1 | 標題列（項目 / 預算 / 比例） |
-| A–B | 2–11 | 10 個支出大類預算 |
+| A–B | 2–10 | 9 個支出大類預算 |
 | A–C | 13 | Total 合計 |
-| E | 1 | 活動清單標題 |
-| E | 2–51 | 活動名稱（最多 50 筆） |
+| E | 1 | 標記清單標題 |
+| E | 2–51 | 標記名稱（最多 50 筆） |
 
 支出大類順序（對應 `topclass[2]` index，必須與年度 sheet 一致）：
 
 ```
 index 0: 飲食   1: 衣裝   2: 居住   3: 交通   4: 教育
-index 5: 娛樂   6: 健康   7: 社交   8: 育兒   9: 其他
+index 5: 娛樂   6: 健康   7: 社交   8: 其他
 ```
 
 ### 年度 sheet（如 `2026`）
 
-Row 11–20，Col B–C：各支出大類年度已使用金額。
+Row 11–19，Col B–C：各支出大類年度已使用金額。
 
 ```
 Row 11: 飲食    Row 12: 衣裝    Row 13: 居住    Row 14: 交通
 Row 15: 教育    Row 16: 娛樂    Row 17: 健康    Row 18: 社交
-Row 19: 育兒    Row 20: 其他
+Row 19: 其他
 ```
 
-> ⚠️ v3.1.1 新增「育兒」（index 8），年度 sheet 需在 row 19 插入育兒統計列，否則已使用金額會錯位。
+> ⚠️ v3.3.0 移除「育兒」大類（改用標記欄位跨類追蹤），類別從 10 個減為 9 個。疫苗移入健康，玩具移入娛樂。
 
 ---
 
@@ -69,10 +69,10 @@ Row 19: 育兒    Row 20: 其他
 
 ```js
 // 預算（config 分頁，跳過標題列）
-const budgets      = { sheetUrl: APP_CONFIG.sheetUrl, sheetTag: 'config',                    row: 2,  col: 1, endRow: 11, endCol: 2 };
+const budgets      = { sheetUrl: APP_CONFIG.sheetUrl, sheetTag: 'config',                    row: 2,  col: 1, endRow: 10, endCol: 2 };
 // 年度已使用金額（當年度 sheet）
-const nowusing     = { sheetUrl: APP_CONFIG.sheetUrl, sheetTag: new Date().getFullYear(),     row: 11, col: 2, endRow: 20, endCol: 3 };
-// 活動清單（config 分頁 E 欄）
+const nowusing     = { sheetUrl: APP_CONFIG.sheetUrl, sheetTag: new Date().getFullYear(),     row: 11, col: 2, endRow: 19, endCol: 3 };
+// 標記清單（config 分頁 E 欄）
 const activityParams = { sheetUrl: APP_CONFIG.sheetUrl, sheetTag: 'config',                  row: 2,  col: 5, endRow: 51, endCol: 5 };
 ```
 
@@ -96,10 +96,35 @@ rowRange = Math.min(rowRange, lastRow - row + 1);
 colRange = Math.min(colRange, lastCol - col + 1);
 ```
 
-### `doPost(e)`（scriptWriteUrl）
+### `doPost(e)`（scriptWriteUrl）— `AddValues.gs`
 
-寫入記帳資料至 `active` sheet（依 header 欄位對應）。
-前端使用 `no-cors` 模式送出，無法讀取回應為正常行為。
+前端一律以 `no-cors` 模式送出，`.then()` 不論成功失敗都會觸發，無法讀取 GAS 回應屬正常行為。
+
+**分支一：寫入記帳資料**（預設，無 `action` 參數）
+
+寫入 `active` sheet，依 header 欄位名稱對應 `e.parameter`。
+
+**分支二：新增標記**（`action=addActivity`，v3.3.0）
+
+```js
+if (e.parameter.action === 'addActivity') {
+    var configSheet = doc.getSheetByName('config')
+    var eRange = configSheet.getRange('E2:E51').getValues()
+    var insertRow = -1
+    for (var i = 0; i < eRange.length; i++) {
+        if (!eRange[i][0]) { insertRow = i + 2; break }
+    }
+    if (insertRow !== -1) {
+        configSheet.getRange(insertRow, 5).setValue(e.parameter.name)
+    }
+    return ContentService
+        .createTextOutput(JSON.stringify({ 'result': 'success' }))
+        .setMimeType(ContentService.MimeType.JSON)
+}
+```
+
+> ⚠️ GAS 修改後須重新部署（Deploy → Manage deployments → New version），否則 endpoint 不更新。
+> ⚠️ `GetRecentValue.gs` 若在頂層（function 外）使用 `$`，會導致整個 GAS 專案崩潰，所有函式都無法執行。
 
 ---
 
@@ -116,22 +141,29 @@ colRange = Math.min(colRange, lastCol - col + 1);
 | Store | Store | 店家 |
 | Detail | Detail | 項目 |
 | Recommendation | Recommendation | 推薦星評 |
-| Remark | Remark | **活動名稱**（config E 欄下拉） |
+| Remark | Remark | **標記名稱**（config E 欄下拉） |
 | Name | Name | 使用者（Jerry_Hu / Alice_Lin） |
 
 ---
 
-## 活動清單管理
+## 標記清單管理
 
-- 維護於 `config` 分頁 E 欄（E1 標題，E2 起為活動名稱）
-- 新增：E 欄末列新增一列；停用：刪除或清空該列
+- 維護於 `config` 分頁 E 欄（E1 標題，E2 起為標記名稱）
+- 格式：`YYMMDD_名稱`（有時效性）或直接輸入名稱（永久不過期）
+- 有前綴的標記：事件日期超過 `ACTIVITY_EXPIRE_DAYS` 天後自動從下拉隱藏（`script.js` 頂部常數，預設 30）
+- 新增：App 內「＋」按鈕（自動填入今日 `YYMMDD_` 前綴）或直接編輯 Sheets E 欄
+- 停用：刪除或清空 Sheets 該列
 - 上限 50 筆（E2:E51）；需要更多請調高 `activityParams.endRow`
-- 編輯 Sheets 後，兩位使用者重新整理 App 即同步
+- Sheets 編輯後，兩位使用者重新整理 App 即同步
+
+### 標記設計意圖
+
+標記作為**跨大類的情境標籤**（例如：育兒、旅行、裝潢），取代原本獨立的「育兒」大類。
+例如兒科疫苗可記為：健康 > 疫苗 + 標記: `育兒`，使健康類別統計涵蓋所有醫療支出。
 
 ---
 
 ## 待辦事項（詳見 TODO.md）
 
-1. **B2 活動管理**：App 內直接新增活動（需修改 GAS `doPost` 加入 `action=addActivity` 分支）
-2. **後台數據儀表板**：網頁版年度統計 + 活動彙整，新增 `dashboard.html`，密碼存於 `config.js`
-3. **Sheets 重整**：複製新試算表取得全新 URL → 更新 GAS 與 GitHub Secrets → 清除 git history 舊 URL
+1. **後台數據儀表板**：網頁版年度統計 + 標記彙整，新增 `dashboard.html`，密碼存於 `config.js`
+2. **Sheets 重整**：複製新試算表取得全新 URL → 更新 GAS 與 GitHub Secrets → 清除 git history 舊 URL

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A lightweight household bookkeeping PWA for two users. Entries are submitted to 
 
 - Income / expense entry with category hierarchy
 - Real-time budget remaining display per expense category
-- Activity tagging — link entries to a trip or event for cross-category aggregation
+- Tag field (標記) — link entries to a trip, project, or context for cross-category aggregation; add tags directly from the app
 - Store / item autocomplete via localStorage
 - Star rating for restaurants and stores
 - Two-user support
@@ -38,18 +38,26 @@ A lightweight household bookkeeping PWA for two users. Entries are submitted to 
 
 ---
 
-## Activity List Management
+## Tag Management
 
-The activity list is maintained in the Google Sheets **`config` tab, column E** (E1 = header, E2 onwards = activity names).
+Tags are maintained in the Google Sheets **`config` tab, column E** (E1 = header, E2 onwards = tag names).
 
-- **Add an activity**: insert a new row below the last entry in column E
-- **Remove an activity**: delete or clear that row
+- **Add a tag from the app**: tap the **＋** button next to the tag dropdown; the app auto-prefixes today's date (`YYMMDD_`)
+- **Add a tag in Sheets**: insert a name in the next empty cell in column E
+- **Disable a tag**: delete or clear that row in column E
+- **Date-prefixed tags** (`YYMMDD_name`) auto-hide from the dropdown 30 days after the event date; unprefixed tags are permanent
 - Changes sync to both users on next app refresh
 - Maximum 50 entries (E2:E51); increase `activityParams.endRow` in [script.js](script.js) if more are needed
 
 ---
 
 ## Release History
+
+- May 04, 2026  **v3.3.0**
+    - Feature: Tag field (標記) — add tags directly from the app via "＋" button; writes to Google Sheets `config` column E via GAS `action=addActivity`
+    - Feature: Date-prefixed tags (`YYMMDD_name`) auto-expire 30 days after event date; unprefixed tags are permanent
+    - Category: Removed 育兒 top-level category; child-related tracking now done via 標記 field; 疫苗 moved to 健康, 玩具 moved to 娛樂
+    - GAS: `doPost` extended with `action=addActivity` branch to append new tags to `config` sheet column E
 
 - May 03, 2026  **v3.2.1**
     - Security: Google Sheets URL moved to `config.js` (gitignored) and `SHEET_URL` Actions secret
@@ -138,8 +146,7 @@ The activity list is maintained in the Google Sheets **`config` tab, column E** 
 
 ## TODO
 
-- **B2**: Add activities directly from the app (currently requires editing Google Sheets)
-- **Analytics dashboard**: Password-protected web dashboard for yearly statistics and activity summaries
+- **Analytics dashboard**: Password-protected web dashboard for yearly statistics and tag summaries
 - **Sheets migration**: Copy spreadsheet to get a new URL, update GAS and GitHub Secrets, clean git history
 
 See [TODO.md](TODO.md) for details.

--- a/TODO.md
+++ b/TODO.md
@@ -1,18 +1,5 @@
 # TODO
 
-## B2：App 內新增活動
-
-目前新增活動需直接編輯 Google Sheets `config` 分頁 E 欄。
-若要在 App 內直接新增：
-
-- GAS `doPost` 加入 `action=addActivity` 分支，寫入 config E 欄下一個空列
-- App 活動下拉旁加「＋」按鈕，輸入後 POST 至 `scriptWriteUrl`
-- 前端樂觀更新（`no-cors` 無法讀取回應，直接加入本地清單）
-
-詳細實作方式可參考對話記錄。
-
----
-
 ## 後台數據儀表板（網頁版）
 
 **背景**
@@ -22,7 +9,7 @@
 **需求**
 - 輸入密碼後進入後台（密碼存於 `config.js`，gitignore 保護）
 - 顯示各年度花費統計（月份 / 類別分析）
-- 顯示各活動花費明細與總額彙整
+- 顯示各標記花費明細與總額彙整
 - 資料來源透過現有 `scriptReadUrl` 從 Google Sheets 讀取
 
 **影響範圍**
@@ -42,5 +29,5 @@
 1. 複製現有試算表 → 取得全新 URL（舊 URL 永久失效）
 2. 在新試算表重新部署 GAS 腳本
 3. 更新 GitHub Secrets：`SHEET_URL`、`SCRIPT_WRITE_URL`、`SCRIPT_READ_URL`
-4. 確認新 Sheets 結構與現有程式碼一致（尤其年度 sheet row 11–20 順序）
+4. 確認新 Sheets 結構與現有程式碼一致（年度 sheet row 11–19，9 個大類）
 5. 選擇性清除 git history 中的舊 URL（`git filter-repo`）

--- a/css/style.css
+++ b/css/style.css
@@ -260,6 +260,94 @@ button[type=button]:active { transform: translateY(0); }
 .alert-warning { color: #856404; background: #fff3cd; border-color: #ffc107; }
 .alert-danger  { color: #721c24; background: #f8d7da; border-color: #f5c6cb; }
 
+/* ── Activity row ─────────────────────────────────────────────────────────── */
+.activity-row {
+    display: flex;
+    gap: 8px;
+}
+
+.activity-row select {
+    flex: 1;
+    margin-bottom: 0;
+}
+
+.activity-row .btn-add-activity {
+    flex: 0 0 40px;
+    padding: 10px 0;
+    border-radius: 8px;
+    border: 1.5px solid var(--primary);
+    background: var(--primary-light);
+    color: var(--primary-dark);
+    font-size: 1.15rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: none;
+    transform: none;
+    line-height: 1;
+    transition: background var(--ease), color var(--ease);
+}
+
+.activity-row .btn-add-activity:hover {
+    background: var(--primary);
+    color: #fff;
+    transform: none;
+    box-shadow: none;
+}
+
+.add-activity-row {
+    margin-top: 6px;
+    gap: 6px;
+    align-items: center;
+}
+
+.add-activity-row input[type=text] {
+    flex: 1;
+    margin-bottom: 0;
+}
+
+.add-activity-row .btn-confirm,
+.add-activity-row .btn-cancel {
+    flex: 0 0 auto;
+    padding: 8px 14px;
+    border-radius: 8px;
+    font-size: 0.88rem;
+    font-weight: 500;
+    cursor: pointer;
+    box-shadow: none;
+    transform: none;
+}
+
+.add-activity-row .btn-confirm {
+    border: none;
+    background: var(--primary);
+    color: #fff;
+}
+
+.add-activity-row .btn-confirm:hover {
+    background: var(--primary-dark);
+    transform: none;
+    box-shadow: none;
+}
+
+.add-activity-row .btn-confirm:disabled {
+    background: #b0bdb0;
+    cursor: not-allowed;
+}
+
+.add-activity-row .btn-cancel {
+    border: 1.5px solid var(--border);
+    background: #fff;
+    color: var(--text-muted);
+}
+
+.add-activity-row .btn-cancel:hover {
+    border-color: var(--text-muted);
+    color: var(--text);
+    background: #f8faf8;
+    transform: none;
+    box-shadow: none;
+}
+
 /* ── Alert message ────────────────────────────────────────────────────────── */
 #msg-alert {
     margin-top: 14px;

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
             <div class="form-card__header">
                 <div class="form-card__title">
                     家用記帳
-                    <span class="form-card__version">v3.2.1</span>
+                    <span class="form-card__version">v3.3.0</span>
                 </div>
                 <div class="form-card__meta">
                     <a href="#" id="sheet-link" target="_blank">試算表</a>
@@ -75,10 +75,19 @@
                     </div>
 
                     <div class="field-group">
-                        <label class="field-label">活動</label>
-                        <select name="Remark" id="remark-list">
-                            <option value="">載入中...</option>
-                        </select>
+                        <label class="field-label">標記</label>
+                        <div class="activity-row">
+                            <select name="Remark" id="remark-list">
+                                <option value="">載入中...</option>
+                            </select>
+                            <button type="button" class="btn-add-activity" onclick="toggleAddActivity()" title="新增標記">＋</button>
+                        </div>
+                        <div id="add-activity-row" class="add-activity-row" style="display:none">
+                            <input type="text" id="new-activity-input" placeholder="YYMMDD_標記名稱" maxlength="30"
+                                   onkeydown="if(event.key==='Enter'){event.preventDefault();confirmAddActivity();}else if(event.key==='Escape'){cancelAddActivity();}">
+                            <button type="button" id="btn-confirm-activity" class="btn-confirm" onclick="confirmAddActivity()">確認</button>
+                            <button type="button" class="btn-cancel" onclick="cancelAddActivity()">取消</button>
+                        </div>
                     </div>
 
                     <div class="field-group">

--- a/script.js
+++ b/script.js
@@ -8,7 +8,7 @@ const scriptReadUrl  = APP_CONFIG.scriptReadUrl;
 const topclass = [
     [],
     ['薪資', '利息', '獎金', '投資', '販賣', '租金', '還款', '副業/兼職', '退稅/補助', '其他'],
-    ['飲食', '衣裝', '居住', '交通', '教育', '娛樂', '健康', '社交', '育兒', '其他']
+    ['飲食', '衣裝', '居住', '交通', '教育', '娛樂', '健康', '社交', '其他']
 ];
 
 const subclass = [
@@ -17,10 +17,9 @@ const subclass = [
     ['房租', '水費', '電費', '瓦斯費', '網路費', '手機費', '日用品', '家電', '家具', '維修費', '管理費'],
     ['汽油燃料', '維修保養', '火車高鐵', '捷運', '公車/客運', '計程車', '飛機', '公共租借', '停車費', '過路費', '汽車用品', '交通卡'],
     ['文具', '書籍', '耗材/材料', '課程學費', '教具'],
-    ['3C產品', '旅宿', '門票', '遊戲', '電影', '數位服務', '國外旅遊', '模型/收藏品'],
-    ['門診', '手術', '藥品', '醫療用品', '運動', '保健食品'],
+    ['3C產品', '旅宿', '門票', '遊戲', '電影', '數位服務', '國外旅遊', '模型/收藏品', '玩具'],
+    ['門診', '手術', '藥品', '醫療用品', '運動', '保健食品', '疫苗'],
     ['捐款', '孝親費', '交際', '貸出', '禮金/禮物'],
-    ['奶粉/副食品', '尿布/衛生用品', '童裝/童鞋', '玩具/繪本', '嬰幼兒用品', '保母費', '托育/幼兒園', '才藝課', '兒科/疫苗', '其他'],
     ['貸款', '稅務', '罰單', '保險', '手續費', '其他']
 ];
 
@@ -137,6 +136,7 @@ function clearEntryFields() {
 }
 
 function OnReset() {
+    cancelAddActivity();
     document.getElementById('fdate').value = todayString();
     changeDate();
     document.getElementById('balance-list').selectedIndex = 0;
@@ -204,12 +204,12 @@ form.addEventListener('submit', e => {
 const budgets = {
     sheetUrl: APP_CONFIG.sheetUrl,
     sheetTag: 'config',
-    row: 2, col: 1, endRow: 11, endCol: 2
+    row: 2, col: 1, endRow: 10, endCol: 2
 };
 const nowusing = {
     sheetUrl: APP_CONFIG.sheetUrl,
     sheetTag: new Date().getFullYear(),
-    row: 11, col: 2, endRow: 20, endCol: 3
+    row: 11, col: 2, endRow: 19, endCol: 3
 };
 const activityParams = {
     sheetUrl: APP_CONFIG.sheetUrl,
@@ -223,10 +223,75 @@ function fetchSheet(params) {
     return fetch(url).then(r => r.text());
 }
 
+// Activities with YYMMDD_ prefix expire after this many days
+var ACTIVITY_EXPIRE_DAYS = 30;
+
+function activityEventDate(raw) {
+    var m = raw.match(/^(\d{2})(\d{2})(\d{2})_/);
+    if (!m) return null;
+    return new Date(2000 + parseInt(m[1], 10), parseInt(m[2], 10) - 1, parseInt(m[3], 10));
+}
+
+function isActivityExpired(raw) {
+    var d = activityEventDate(raw);
+    if (!d) return false;
+    return Date.now() - d.getTime() > ACTIVITY_EXPIRE_DAYS * 86400000;
+}
+
 function populateActivities() {
     var el = document.getElementById('remark-list');
     el.innerHTML = '<option value="">-</option>' +
-        arrActivities.map(a => '<option value="' + a + '">' + a + '</option>').join('');
+        arrActivities
+            .filter(a => !isActivityExpired(a))
+            .map(a => '<option value="' + a + '">' + a + '</option>')
+            .join('');
+}
+
+function toggleAddActivity() {
+    var row = document.getElementById('add-activity-row');
+    if (row.style.display !== 'none') {
+        cancelAddActivity();
+    } else {
+        row.style.display = 'flex';
+        var d = new Date();
+        var prefix = String(d.getFullYear()).slice(-2)
+            + String(d.getMonth() + 1).padStart(2, '0')
+            + String(d.getDate()).padStart(2, '0') + '_';
+        var input = document.getElementById('new-activity-input');
+        input.value = prefix;
+        input.focus();
+        input.setSelectionRange(prefix.length, prefix.length);
+    }
+}
+
+function cancelAddActivity() {
+    document.getElementById('add-activity-row').style.display = 'none';
+}
+
+function confirmAddActivity() {
+    var name = document.getElementById('new-activity-input').value.trim();
+    if (!name) { showMessage('請輸入標記名稱', 'warning'); return; }
+    if (name.includes(',')) { showMessage('標記名稱不可包含逗號', 'warning'); return; }
+    if (arrActivities.includes(name)) { showMessage('標記已存在', 'warning'); return; }
+
+    var btn = document.getElementById('btn-confirm-activity');
+    btn.disabled = true;
+
+    var fd = new FormData();
+    fd.append('action', 'addActivity');
+    fd.append('name', name);
+    fetch(scriptWriteUrl, { method: 'POST', body: fd, mode: 'no-cors' })
+        .then(() => {
+            arrActivities.push(name);
+            populateActivities();
+            document.getElementById('remark-list').value = name;
+            cancelAddActivity();
+            showMessage('標記「' + name + '」已新增', 'success');
+        })
+        .catch(() => {
+            showMessage('網路錯誤，活動新增失敗', 'danger');
+        })
+        .finally(() => { btn.disabled = false; });
 }
 
 (async () => {


### PR DESCRIPTION
- Add "＋" button to tag field; GAS doPost handles action=addActivity
- Date-prefixed tags (YYMMDD_name) auto-expire after 30 days
- Remove parenting top-level category; vaccine → health, toy → entertainment
- Rename activity field to tag throughout
- Update budget/usage fetch ranges (endRow 11→10, 20→19)
- Update deploy.yml use Node.js 24