### PR TITLE
[Fix]: rename Remark→Tag and fix mobile toast visibility (v3.3.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 家用記帳 PWA，使用者為 Jerry_Hu 與 Alice_Lin 兩人家庭。
 前端純 Vanilla JS，後端為 Google Apps Script + Google Sheets，透過 GitHub Actions 部署。
 
-- **目前版本**：v3.3.0
+- **目前版本**：v3.3.1
 - **Sheets URL**：存於 `config.js`（gitignored），不在原始碼中
 
 ---
@@ -141,7 +141,7 @@ if (e.parameter.action === 'addActivity') {
 | Store | Store | 店家 |
 | Detail | Detail | 項目 |
 | Recommendation | Recommendation | 推薦星評 |
-| Remark | Remark | **標記名稱**（config E 欄下拉） |
+| Tag | Tag | **標記名稱**（config E 欄下拉） |
 | Name | Name | 使用者（Jerry_Hu / Alice_Lin） |
 
 ---

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Tags are maintained in the Google Sheets **`config` tab, column E** (E1 = header
 
 ## Release History
 
+- May 07, 2026  **v3.3.1**
+    - Fix: renamed form field `Remark` → `Tag` to match intended Sheets column header
+    - UX: success/warning toast is now a fixed overlay at the top of the screen — no longer hidden by the mobile keyboard after submission
+
 - May 04, 2026  **v3.3.0**
     - Feature: Tag field (標記) — add tags directly from the app via "＋" button; writes to Google Sheets `config` column E via GAS `action=addActivity`
     - Feature: Date-prefixed tags (`YYMMDD_name`) auto-expire 30 days after event date; unprefixed tags are permanent

--- a/css/style.css
+++ b/css/style.css
@@ -348,10 +348,24 @@ button[type=button]:active { transform: translateY(0); }
     box-shadow: none;
 }
 
-/* ── Alert message ────────────────────────────────────────────────────────── */
+/* ── Alert message (fixed toast at top) ──────────────────────────────────── */
 #msg-alert {
-    margin-top: 14px;
+    position: fixed;
+    top: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 9999;
+    min-width: 200px;
+    max-width: calc(100vw - 32px);
     border-radius: 8px;
     font-size: 0.9rem;
-    padding: 10px 14px;
+    padding: 10px 18px;
+    text-align: center;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    animation: toast-in 0.2s ease;
+}
+
+@keyframes toast-in {
+    from { opacity: 0; transform: translateX(-50%) translateY(-8px); }
+    to   { opacity: 1; transform: translateX(-50%) translateY(0); }
 }

--- a/index.html
+++ b/index.html
@@ -22,13 +22,14 @@
 </head>
 
 <body>
+    <div id="msg-alert" class="alert d-none" role="alert"></div>
     <main id="form">
         <div class="form-card">
 
             <div class="form-card__header">
                 <div class="form-card__title">
                     家用記帳
-                    <span class="form-card__version">v3.3.0</span>
+                    <span class="form-card__version">v3.3.1</span>
                 </div>
                 <div class="form-card__meta">
                     <a href="#" id="sheet-link" target="_blank">試算表</a>
@@ -77,7 +78,7 @@
                     <div class="field-group">
                         <label class="field-label">標記</label>
                         <div class="activity-row">
-                            <select name="Remark" id="remark-list">
+                            <select name="Tag" id="remark-list">
                                 <option value="">載入中...</option>
                             </select>
                             <button type="button" class="btn-add-activity" onclick="toggleAddActivity()" title="新增標記">＋</button>
@@ -108,7 +109,6 @@
                         <button type="submit" id="btn-submit">Send</button>
                         <button type="button" onclick="OnReset()">Reset</button>
                     </div>
-                    <div id="msg-alert" class="alert d-none" role="alert"></div>
                 </form>
             </div>
 

--- a/script.js
+++ b/script.js
@@ -65,7 +65,7 @@ function showMessage(msg, type) {
     el.className = 'alert alert-' + type;
     el.textContent = msg;
     clearTimeout(el._timer);
-    el._timer = setTimeout(() => { el.className = 'alert d-none'; }, 4000);
+    el._timer = setTimeout(() => { el.className = 'alert d-none'; }, 3000);
 }
 
 // ── Event handlers (called from inline HTML onchange / onclick) ───────────────
@@ -131,7 +131,7 @@ function clearEntryFields() {
     document.getElementById('store').value = '';
     document.getElementById('detail').value = '';
     document.getElementById('star-list').selectedIndex = 0;
-    form.querySelector('[name=Remark]').value = '';
+    form.querySelector('[name=Tag]').value = '';
     document.getElementById('price').focus();
 }
 
@@ -149,7 +149,7 @@ function OnReset() {
     document.getElementById('store').value = '';
     document.getElementById('detail').value = '';
     document.getElementById('star-list').selectedIndex = 0;
-    form.querySelector('[name=Remark]').value = '';
+    form.querySelector('[name=Tag]').value = '';
 }
 
 // ── Initialization (script has defer, so DOM is ready here) ───────────────────


### PR DESCRIPTION
- Rename form field name="Remark" to name="Tag" across HTML and JS to match the intended Google Sheets column header
- Move #msg-alert outside the form to body level and make it a position:fixed toast at the top of the screen so it is not covered by the mobile keyboard after submission
- Reduce toast display duration from 4s to 3s